### PR TITLE
Adds barotropic gyre experiment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+Manifest.toml
+*.swp

--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,3 @@
+[deps]
+Oceananigans = "9e8cae18-63c1-5223-a75c-80ca9d6e9a09"
+Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"

--- a/barotropic_gyre.jl
+++ b/barotropic_gyre.jl
@@ -1,47 +1,42 @@
+# Adapted from https://github.com/CliMA/Oceananigans.jl/blob/main/validation/barotropic_gyre/barotropic_gyre.jl
+
 using Oceananigans
+using Oceananigans.Units
 using Oceananigans: time_step!
 using Printf
 
-Nx = 60
-Ny = 60
-
-# A spherical domain
-grid = LatitudeLongitudeGrid(size = (Nx, Ny, 1),
+grid = LatitudeLongitudeGrid(size = (60, 60, 1),
                              longitude = (-30, 30),
                              latitude = (15, 75),
                              z = (-4000, 0))
 
-@show surface_wind_stress_parameters = (τ₀ = 1e-4,
-                                        Lφ = grid.Ly,
-                                        φ₀ = 15)
+@inline wind_stress(λ, φ, t, p) = p.τ₀ * cos(2π * (φ - p.φ₀) / p.Lφ)
+wind_stress_bc = FluxBoundaryCondition(wind_stress, parameters = (τ₀=1e-4, Lφ=grid.Ly, φ₀=15))
 
-@inline surface_wind_stress(λ, φ, t, p) = p.τ₀ * cos(2π * (φ - p.φ₀) / p.Lφ)
-
-surface_wind_stress_bc = FluxBoundaryCondition(surface_wind_stress,
-                                               parameters = surface_wind_stress_parameters)
-
-μ = 1 / 60days
 @inline u_bottom_drag(i, j, grid, clock, fields, μ) = @inbounds - μ * fields.u[i, j, 1]
 @inline v_bottom_drag(i, j, grid, clock, fields, μ) = @inbounds - μ * fields.v[i, j, 1]
 
-u_bottom_drag_bc = FluxBoundaryCondition(u_bottom_drag, discrete_form = true, parameters = μ)
-v_bottom_drag_bc = FluxBoundaryCondition(v_bottom_drag, discrete_form = true, parameters = μ)
+μ = 1 / 60days
+u_bottom_drag_bc = FluxBoundaryCondition(u_bottom_drag, discrete_form=true, parameters=μ)
+v_bottom_drag_bc = FluxBoundaryCondition(v_bottom_drag, discrete_form=true, parameters=μ)
 
-u_bcs = FieldBoundaryConditions(top = surface_wind_stress_bc, bottom = u_bottom_drag_bc)
-v_bcs = FieldBoundaryConditions(bottom = v_bottom_drag_bc)
+u_bcs = FieldBoundaryConditions(top=surface_wind_stress_bc, bottom=u_bottom_drag_bc)
+v_bcs = FieldBoundaryConditions(bottom=v_bottom_drag_bc)
 
 νh₀ = 5e3 * (60 / grid.Nx)^2
-constant_horizontal_diffusivity = HorizontalScalarDiffusivity(ν = νh₀)
+closure = HorizontalScalarDiffusivity(ν = νh₀)
 
-model = HydrostaticFreeSurfaceModel(; grid,
+model = HydrostaticFreeSurfaceModel(; grid, closure,
                                     momentum_advection = VectorInvariant(),
-                                    free_surface = ImplicitFreeSurface(gravitational_acceleration=0.1),
                                     coriolis = HydrostaticSphericalCoriolis(),
                                     boundary_conditions = (u=u_bcs, v=v_bcs),
-                                    closure = constant_horizontal_diffusivity,
                                     tracers = nothing,
                                     buoyancy = nothing)
 
+@info "Before taking a time step"
+@show maximum(model.velocities.u)
+
 time_step!(model, 6hours)
 
+@info "After taking a time step"
 @show maximum(model.velocities.u)

--- a/barotropic_gyre.jl
+++ b/barotropic_gyre.jl
@@ -1,0 +1,47 @@
+using Oceananigans
+using Oceananigans: time_step!
+using Printf
+
+Nx = 60
+Ny = 60
+
+# A spherical domain
+grid = LatitudeLongitudeGrid(size = (Nx, Ny, 1),
+                             longitude = (-30, 30),
+                             latitude = (15, 75),
+                             z = (-4000, 0))
+
+@show surface_wind_stress_parameters = (τ₀ = 1e-4,
+                                        Lφ = grid.Ly,
+                                        φ₀ = 15)
+
+@inline surface_wind_stress(λ, φ, t, p) = p.τ₀ * cos(2π * (φ - p.φ₀) / p.Lφ)
+
+surface_wind_stress_bc = FluxBoundaryCondition(surface_wind_stress,
+                                               parameters = surface_wind_stress_parameters)
+
+μ = 1 / 60days
+@inline u_bottom_drag(i, j, grid, clock, fields, μ) = @inbounds - μ * fields.u[i, j, 1]
+@inline v_bottom_drag(i, j, grid, clock, fields, μ) = @inbounds - μ * fields.v[i, j, 1]
+
+u_bottom_drag_bc = FluxBoundaryCondition(u_bottom_drag, discrete_form = true, parameters = μ)
+v_bottom_drag_bc = FluxBoundaryCondition(v_bottom_drag, discrete_form = true, parameters = μ)
+
+u_bcs = FieldBoundaryConditions(top = surface_wind_stress_bc, bottom = u_bottom_drag_bc)
+v_bcs = FieldBoundaryConditions(bottom = v_bottom_drag_bc)
+
+νh₀ = 5e3 * (60 / grid.Nx)^2
+constant_horizontal_diffusivity = HorizontalScalarDiffusivity(ν = νh₀)
+
+model = HydrostaticFreeSurfaceModel(; grid,
+                                    momentum_advection = VectorInvariant(),
+                                    free_surface = ImplicitFreeSurface(gravitational_acceleration=0.1),
+                                    coriolis = HydrostaticSphericalCoriolis(),
+                                    boundary_conditions = (u=u_bcs, v=v_bcs),
+                                    closure = constant_horizontal_diffusivity,
+                                    tracers = nothing,
+                                    buoyancy = nothing)
+
+time_step!(model, 6hours)
+
+@show maximum(model.velocities.u)


### PR DESCRIPTION
This PR adds a short script that implements a barotropic gyre numerical experiment and takes one time-step.

To use the code in this PR, first install julia, open it, and type

```julia
using Pkg
Pkg.instantiate() # install Oceananigans
```

You may want to check which version of Oceananigans got installed:

```julia
Pkg.status()
```

As of writing this the latest version is 0.77.1:

https://github.com/CliMA/Oceananigans.jl/blob/2234f02afdb83815ffd1134033b25c09477ddeac/Project.toml#L4

Other versions could be installed if there are conflicting packages in your global Julia environment (but isn't super likely).

Then to run the experiment with:

```julia
include("barotropic_gyre.jl")
```

For me this produces

```julia
julia> include("barotropic_gyre.jl")
[ Info: Before taking a time step
maximum(model.velocities.u) = 0.0
[ Info: After taking a time step
maximum(model.velocities.u) = 0.00042234377596929684
```